### PR TITLE
Added restart for State Machine

### DIFF
--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -1301,6 +1301,10 @@ void StartReadCommands(void const * argument)
     {
       // set command echo
       char c_echo[] = "CAL";
+
+      Mission_Data.STATE = "LAUNCH_PAD";
+      memset(altitude_history, 0, 3);
+
       strcpy(global_mission_data.CMD_ECHO, c_echo);
     }
     // MEC WIRE ON command -> actuate (servos?)

--- a/Drivers/MS5607/MS5607SPI.c
+++ b/Drivers/MS5607/MS5607SPI.c
@@ -332,13 +332,13 @@ void MS5607SetPressureOSR(MS5607OSRFactors pOSR)
 /*
   AltitudeCalculations.c START HERE
 */
-float const lower_altitude_threshold = 20.0;
+float const lower_altitude_threshold = 50.0;
 
 // Index is by seconds ago the value was calculated
 float altitude_history[] = {0, 0, 0};
 
 float max_altitude = 0.0;
-float apogee_base_ratio = 0.75; 
+float apogee_base_ratio = 0.80;
 float apogee_difference_ratio = 0.00;
 float const apogee_offset_height = 15.00;
 


### PR DESCRIPTION
Restarted the state machine and altitude history when we receive a CAL command.

A potential solution to #28.

Also edited some constants to make it more accurate to this year's requirements.